### PR TITLE
Annotations and Labels

### DIFF
--- a/charts/workload/templates/_helpers.tpl
+++ b/charts/workload/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Create chart name and version as used by the chart label.
 {{/*
 Common labels
 */}}
-{{- define "workload.labels" -}}
+{{- define "workload.commonLabels" -}}
 helm.sh/chart: {{ include "workload.chart" . }}
 {{ include "workload.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -13,8 +13,11 @@ spec:
       {{- include "workload.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- toYaml .Values.workload.containers.annotations | nindent 8 }}
       labels:
         {{- include "workload.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.workload.containers.labels | nindent 8 }}
     spec:
       containers:
         {{- range $name, $container := .Values.containers }}

--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   annotations:
     {{- toYaml .Values.workload.annotations | nindent 4 }}
   labels:
-    {{- include "workload.labels" . | nindent 4 }}
+    {{- include "workload.commonLabels" . | nindent 4 }}
+    {{- toYaml .Values.workload.labels | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "workload.name" . }}
+  annotations:
+    {{- toYaml .Values.workload.annotations | nindent 4 }}
   labels:
     {{- include "workload.labels" . | nindent 4 }}
 spec:

--- a/charts/workload/templates/service.yaml
+++ b/charts/workload/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "workload.name" . }}
   labels:
     {{- include "workload.labels" . | nindent 4 }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/workload/templates/service.yaml
+++ b/charts/workload/templates/service.yaml
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "workload.name" . }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
   labels:
-    {{- include "workload.labels" . | nindent 4 }}
+    {{- include "workload.commonLabels" . | nindent 4 }}
     {{- toYaml .Values.service.labels | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Ability to add `labels` and `annotations` to both `Deployment` and `Service`.

## What does this change do?

This PR add a way to add `labels` and `annotations` on both the `Deployment` and the `Service`.

Here are some use cases:

- Radius: `--set "workload.annotations.radapp\.io/enabled=true"` - example here: https://github.com/mathieu-benoit/score-radius
- Dapr: `--set "workload.containers.annotations.dapr\.io/enabled=true"`

In order to accomplish this as an example:
```
score-helm run \
	-f score.yaml \
	-o score-helm-values.yaml

helm install \
	test \
	--repo https://score-spec.github.io/score-helm-charts \
	workload \
	--values score-helm-values.yaml \
        --set "workload.annotations.radapp\.io/enabled=true" \
        --set "workload.containers.annotations.dapr\.io/enabled=true"
```

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
