### PR TITLE
Fix `annotations` and `labels` with `int` and `bool`

### DIFF
--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -4,12 +4,14 @@ metadata:
   name: {{ include "workload.name" . }}
   {{- if and .Values.workload .Values.workload.annotations }}
   annotations:
-    {{- toYaml .Values.workload.annotations | nindent 4 }}
+    {{- range $key, $val := .Values.workload.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "workload.commonLabels" . | nindent 4 }}
-    {{- if and .Values.workload .Values.workload.labels }}
-    {{- toYaml .Values.workload.labels | nindent 4 }}
+    {{- range $key, $val := .Values.workload.labels }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
 spec:
   selector:
@@ -19,12 +21,14 @@ spec:
     metadata:
       {{- if and .Values.workload .Values.workload.containers .Values.workload.containers.annotations }}
       annotations:
-        {{- toYaml .Values.workload.containers.annotations | nindent 8 }}
+        {{- range $key, $val := .Values.workload.containers.annotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "workload.selectorLabels" . | nindent 8 }}
-        {{- if and .Values.workload .Values.workload.containers .Values.workload.containers.labels }}
-        {{- toYaml .Values.workload.containers.labels | nindent 8 }}
+        {{- range $key, $val := .Values.workload.containers.labels }}
+        {{ $key }}: {{ $val | quote }}
         {{- end }}
     spec:
       containers:

--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -10,8 +10,10 @@ metadata:
   {{- end }}
   labels:
     {{- include "workload.commonLabels" . | nindent 4 }}
+    {{- if and .Values.workload .Values.workload.labels }}
     {{- range $key, $val := .Values.workload.labels }}
     {{ $key }}: {{ $val | quote }}
+    {{- end }}
     {{- end }}
 spec:
   selector:
@@ -27,8 +29,10 @@ spec:
       {{- end }}
       labels:
         {{- include "workload.selectorLabels" . | nindent 8 }}
+        {{- if and .Values.workload .Values.workload.containers .Values.workload.containers.labels }}
         {{- range $key, $val := .Values.workload.containers.labels }}
         {{ $key }}: {{ $val | quote }}
+        {{- end }}
         {{- end }}
     spec:
       containers:

--- a/charts/workload/templates/service.yaml
+++ b/charts/workload/templates/service.yaml
@@ -5,12 +5,14 @@ metadata:
   name: {{ include "workload.name" . }}
   {{- if .Values.service.annotations }}
   annotations:
-    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "workload.commonLabels" . | nindent 4 }}
-    {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- range $key, $val := .Values.service.labels }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/workload/templates/service.yaml
+++ b/charts/workload/templates/service.yaml
@@ -11,8 +11,10 @@ metadata:
   {{- end }}
   labels:
     {{- include "workload.commonLabels" . | nindent 4 }}
+    {{- if .Values.service.labels }}
     {{- range $key, $val := .Values.service.labels }}
     {{ $key }}: {{ $val | quote }}
+    {{- end }}
     {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
When running this:
```bash
helm upgrade \
    workload \
    ./charts/workload/ \
    --values values.yaml \
    --set workload.containers.annotations."dapr\.io/enabled"=true \
    --set workload.containers.annotations."dapr\.io/app-port"=3000 \
    --set workload.containers.annotations."dapr\.io/app-id"=nodeapp
```
We are getting this error:
```none
Error: INSTALLATION FAILED: 1 error occurred:
        * Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field ObjectMeta.spec.template.metadata.annotations of type string
```
This is a known issue/feature about `toYaml` not meant to translate `bool` nor `int` properly.

Before the fix, this:
```bash
helm template charts/workload/ \
--set workload.containers.annotations."dapr\.io/enabled"=true \
--set workload.containers.annotations."dapr\.io/app-port"=3000 \
--set workload.containers.annotations."dapr\.io/app-id"=nodeapp
```
Was generating this:
```yaml
  template:
    metadata:
      annotations:
        dapr.io/app-id: nodeapp
        dapr.io/app-port: 3000
        dapr.io/enabled: true
```
Now with the fix it's generating this:
```yaml
  template:
    metadata:
      annotations:
        dapr.io/app-id: "nodeapp"
        dapr.io/app-port: "3000"
        dapr.io/enabled: "true"
```
And can now be installed properly in Kubernetes via `helm upgrade|install`.